### PR TITLE
Add support for disabling page navigation

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -108,6 +108,8 @@ module.exports = {
       { title: 'GitHub', path: 'https://github.com/mgks/docmd', icon: 'github', external: true },
       { title: 'Support the Project', path: 'https://github.com/sponsors/mgks', icon: 'heart', external: true },
     ],
+    
+  pageNavigation: true, // Enable previous / next page navigation at the bottom of each page
 
   // Sponsor Ribbon Configuration
   Sponsor: {

--- a/src/core/config-loader.js
+++ b/src/core/config-loader.js
@@ -20,6 +20,7 @@ async function loadConfig(configPath) {
     config.theme = config.theme || {};
     config.theme.defaultMode = config.theme.defaultMode || 'light';
     config.navigation = config.navigation || [{ title: 'Home', path: '/' }];
+    config.pageNavigation = config.pageNavigation ?? true;
 
     return config;
   } catch (e) {

--- a/src/templates/layout.ejs
+++ b/src/templates/layout.ejs
@@ -79,7 +79,7 @@
                 <div class="main-content">
                     <%- content %>
                     
-                    <% if (prevPage || nextPage) { %>
+                    <% if (config.pageNavigation && (prevPage || nextPage)) { %>
                     <div class="page-navigation">
                         <% if (prevPage) { %>
                         <a href="<%= prevPage.url %>" class="prev-page">


### PR DESCRIPTION
This PR adds an option `pageNavigation` for `config.js` that allows users to skip the generation of previous / next page navigation buttons.

There are two scenarios that come to my mind why this would be necessary:

1) Documentations that consist mostly of a single page (index.md), where the sidebar contains links to that page. For example: `{ title: 'Examples', path: '#examples' }` <- references the 'Examples' section in index.md

2) Documentations where the structure of the sidebar does not correlate with a specific order. For example, a manual that simply contains isolated how-tos, where the user is not expected to read it from start to finish.

I personally needed this feature for scenario 1), which is why I implemented it, and I think it would be a nice-to-have in docmd.

I'm not a JS guru by any means, so feel free to let me know if something is wrong.