### PR TITLE
feat(parser): export createDepthTrackingContainer for plugin use

### DIFF
--- a/packages/parser/src/features/common-containers.ts
+++ b/packages/parser/src/features/common-containers.ts
@@ -32,7 +32,26 @@ function smartDedent(str) {
   ).join('\n');
 }
 
-function createDepthTrackingContainer(md, name, renderOpen, renderClose) {
+/**
+ * Creates a depth-tracking container block rule for markdown-it.
+ * Handles arbitrary nesting of `:::` containers by tracking open/close depth.
+ *
+ * @example
+ * ```ts
+ * import { createDepthTrackingContainer } from '@docmd/parser';
+ *
+ * createDepthTrackingContainer(md, 'note',
+ *   (tokens, idx) => `<div class="note">\n`,
+ *   () => '</div>\n'
+ * );
+ * ```
+ *
+ * @param md - The markdown-it instance
+ * @param name - Container name (matched after `:::`)
+ * @param renderOpen - Renderer for the opening token
+ * @param renderClose - Renderer for the closing token
+ */
+export function createDepthTrackingContainer(md, name, renderOpen, renderClose) {
   md.block.ruler.before('fence', `custom_${name}`, (state, startLine, endLine, silent) => {
     const start = state.bMarks[startLine] + state.tShift[startLine];
     const max = state.eMarks[startLine];

--- a/packages/parser/src/features/index.ts
+++ b/packages/parser/src/features/index.ts
@@ -13,6 +13,7 @@
  */
 
 import common from './common-containers.js';
+export { createDepthTrackingContainer } from './common-containers.js';
 import tabs from './tabs.js';
 import steps from './steps.js';
 import changelog from './changelog.js';

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -27,3 +27,5 @@ export {
   // Utils
   renderIcon
 };
+
+export { createDepthTrackingContainer } from './features/index.js';


### PR DESCRIPTION
## Summary

- Exports `createDepthTrackingContainer` from `@docmd/parser`'s public API so plugins can register custom `:::` container syntax
- Re-exports through `features/index.ts` → `parser/index.ts`
- Adds JSDoc documentation with usage example

## Context

This is part of the plugin API infrastructure discussed in #73. Plugins like the threads/discussion plugin need to register custom containers (`::: threads`, `::: comment`, etc.) using the same depth-tracking mechanism that `@docmd/parser` uses internally for callouts, cards, and collapsibles.

The function already exists in `common-containers.ts` — this PR simply adds the `export` keyword and re-exports it through the package's public API.

## Test plan

- [ ] Import `createDepthTrackingContainer` from `@docmd/parser` and verify it's accessible
- [ ] Register a custom container and verify it renders correctly
- [ ] Run `pnpm test` (failsafe suite)