### PR TITLE
feat(core): add action dispatcher and source editing tools

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,10 @@ export { buildSite as build } from './commands/build.js';
 export { startDevServer as dev } from './commands/dev.js';
 export { buildLive } from './commands/live.js';
 
+// Action dispatcher and source editing tools
+export { createActionDispatcher, safePath } from './utils/action-dispatcher.js';
+export { createSourceTools } from './utils/source-tools.js';
+
 // Plugin API types
 export type {
   ActionContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,3 +19,16 @@ export function defineConfig(config: any): any {
 export { buildSite as build } from './commands/build.js';
 export { startDevServer as dev } from './commands/dev.js';
 export { buildLive } from './commands/live.js';
+
+// Plugin API types
+export type {
+  ActionContext,
+  ActionHandler,
+  EventHandler,
+  DispatchResult,
+  PluginModule,
+  SourceTools,
+  BlockInfo,
+  InlineSegment,
+  TextLocation,
+} from './types.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Context provided to plugin action and event handlers.
+ *
+ * Contains file I/O helpers, source editing tools, and project metadata.
+ * All file operations are sandboxed to the project root directory.
+ */
+export interface ActionContext {
+  /** Absolute path to the project root directory. */
+  projectRoot: string;
+  /** Current docmd site configuration. */
+  config: any;
+  /** Read a file relative to the project root. */
+  readFile(relativePath: string): Promise<string>;
+  /** Write a file relative to the project root. Sets the modification flag. */
+  writeFile(relativePath: string, content: string): Promise<void>;
+  /** Read a file as an array of lines. */
+  readFileLines(relativePath: string): Promise<string[]>;
+  /** Broadcast an event to all connected browser clients. */
+  broadcast(event: string, data: any): void;
+  /** Source editing tools for block-level markdown manipulation. */
+  source: SourceTools;
+}
+
+/**
+ * Source editing tools that translate rendered-output references
+ * (block IDs, text offsets) back to raw markdown source positions.
+ */
+export interface SourceTools {
+  /** Get block content and inline segments at a given source map reference. */
+  getBlockAt(file: string, blockRef: [number, number], options?: { textOffset?: number }): Promise<BlockInfo>;
+  /** Locate text within a block and return its source position. */
+  findText(file: string, blockRef: [number, number], text: string, textOffset?: number): Promise<TextLocation | null>;
+  /** Wrap text within a block with syntax markers (e.g., `==`, `**`). */
+  wrapText(file: string, blockRef: [number, number], text: string, textOffset: number, before: string, after: string): Promise<void>;
+  /** Insert markdown content after a block. */
+  insertAfter(file: string, blockRef: [number, number], content: string): Promise<void>;
+  /** Replace an entire block's source lines. */
+  replaceBlock(file: string, blockRef: [number, number], content: string): Promise<void>;
+  /** Remove a block's source lines. */
+  removeBlock(file: string, blockRef: [number, number]): Promise<void>;
+}
+
+/** Information about a block in the markdown source. */
+export interface BlockInfo {
+  id: string | null;
+  line: { start: number; end: number };
+  raw: string;
+  textContent: string;
+  segments: InlineSegment[];
+  cursor: InlineSegment | null;
+  ancestors: any[];
+}
+
+/** A contiguous run of text content with optional surrounding syntax. */
+export interface InlineSegment {
+  text: string;
+  rawOffset: number;
+  rawLength: number;
+  syntax: [string, string] | null;
+}
+
+/** Source position of located text within a block. */
+export interface TextLocation {
+  line: number;
+  startCol: number;
+  endCol: number;
+  rawText: string;
+  wrappingSyntax: { before: string | null; after: string | null };
+}
+
+/**
+ * Handler for a named plugin action (WebSocket RPC).
+ * Returns a result that is sent back to the browser client.
+ */
+export type ActionHandler = (payload: any, ctx: ActionContext) => Promise<any>;
+
+/** Handler for a fire-and-forget plugin event. */
+export type EventHandler = (data: any, ctx: ActionContext) => void;
+
+/** Result of dispatching an action call. */
+export interface DispatchResult {
+  result: any;
+  reload: boolean;
+}
+
+/**
+ * Interface for a docmd plugin module.
+ *
+ * Plugins can export any combination of build-time hooks and runtime
+ * action/event handlers.
+ */
+export interface PluginModule {
+  /** Extend the markdown-it parser instance. */
+  markdownSetup?(md: any, options?: any): void;
+  /** Inject meta/link tags into the HTML head. */
+  generateMetaTags?(config: any, page: any, relativePathToRoot: string): string | Promise<string>;
+  /** Inject scripts into head and/or body. */
+  generateScripts?(config: any, options?: any): { headScriptsHtml?: string; bodyScriptsHtml?: string };
+  /** Define external assets (JS/CSS) to inject. */
+  getAssets?(options?: any): any[];
+  /** Run logic after all HTML files are generated. */
+  onPostBuild?(ctx: any): Promise<void>;
+  /** Named action handlers for WebSocket RPC calls from the browser. */
+  actions?: Record<string, ActionHandler>;
+  /** Named event handlers for fire-and-forget messages from the browser. */
+  events?: Record<string, EventHandler>;
+}

--- a/packages/core/src/utils/action-dispatcher.ts
+++ b/packages/core/src/utils/action-dispatcher.ts
@@ -1,0 +1,116 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Action dispatcher for live-edit WebSocket message handling.
+ *
+ * Routes incoming `call` messages to plugin action handlers and `event`
+ * messages to plugin event handlers.  Each call gets a fresh context with
+ * file I/O helpers and source editing tools.  Tracks modifications so the
+ * caller knows whether a browser reload is needed.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createSourceTools } from './source-tools.js';
+import type {
+  ActionContext,
+  ActionHandler,
+  EventHandler,
+  DispatchResult,
+} from '../types.js';
+
+/**
+ * Resolve a relative path against the project root, rejecting any path
+ * that would escape the root directory.
+ */
+export function safePath(root: string, relativePath: string): string {
+  const resolved = path.resolve(root, relativePath);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw new Error(`Path escapes project root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+interface DispatcherHooks {
+  actions: Record<string, ActionHandler>;
+  events: Record<string, EventHandler>;
+}
+
+interface DispatcherOptions {
+  projectRoot: string;
+  config: any;
+  broadcast: (event: string, data: any) => void;
+}
+
+/**
+ * Create an action dispatcher bound to the given hooks and project context.
+ *
+ * @param hooks     - `{ actions: {name: handler}, events: {name: handler} }`
+ * @param options   - Project root, config, and broadcast function
+ * @returns `{ handleCall, handleEvent }`
+ */
+export function createActionDispatcher(hooks: DispatcherHooks, options: DispatcherOptions) {
+  const { projectRoot, config, broadcast } = options;
+
+  return {
+    /**
+     * Dispatch a call-style action.  Returns `{ result, reload }`.
+     */
+    async handleCall(action: string, payload: any): Promise<DispatchResult> {
+      const handler = hooks.actions[action];
+      if (!handler) throw new Error(`Unknown action: ${action}`);
+
+      const sourceTools = createSourceTools({ projectRoot });
+      let modified = false;
+
+      const ctx: ActionContext = {
+        projectRoot,
+        config,
+        broadcast,
+        source: sourceTools,
+        async readFile(relativePath: string): Promise<string> {
+          const resolved = safePath(projectRoot, relativePath);
+          return fs.promises.readFile(resolved, 'utf8');
+        },
+        async writeFile(relativePath: string, content: string): Promise<void> {
+          const resolved = safePath(projectRoot, relativePath);
+          await fs.promises.writeFile(resolved, content);
+          modified = true;
+        },
+        async readFileLines(relativePath: string): Promise<string[]> {
+          const content = await ctx.readFile(relativePath);
+          return content.split('\n');
+        },
+      };
+
+      const result = await handler(payload, ctx);
+      return { result, reload: modified || sourceTools._modified };
+    },
+
+    /**
+     * Dispatch a fire-and-forget event.  Unknown events are silently ignored.
+     */
+    handleEvent(name: string, data: any): void {
+      const handler = hooks.events[name];
+      if (!handler) return;
+      const ctx = { projectRoot, config, broadcast } as ActionContext;
+      try {
+        handler(data, ctx);
+      } catch (e: any) {
+        console.error(`Event handler error [${name}]:`, e.message);
+      }
+    },
+  };
+}

--- a/packages/core/src/utils/plugin-loader.ts
+++ b/packages/core/src/utils/plugin-loader.ts
@@ -24,7 +24,9 @@ export const hooks: any = {
   injectBody: [],
   onPostBuild: [],
   assets: [],
-  getClientAssets: [] // Legacy support
+  getClientAssets: [], // Legacy support
+  actions: {},         // action name → handler function (for WebSocket RPC)
+  events: {}           // event name → handler function (fire-and-forget)
 };
 
 // Map short names to package names
@@ -40,7 +42,9 @@ const ALIASES: Record<string, string> = {
 
 export async function loadPlugins(config: any) {
   // 1. Reset hooks
-  Object.keys(hooks).forEach(key => hooks[key] = []);
+  Object.keys(hooks).forEach(key => {
+    hooks[key] = Array.isArray(hooks[key]) ? [] : {};
+  });
 
   // 2. Initialize Plugin Map (Name -> Options)
   // This ensures unique plugins (last write wins)
@@ -111,4 +115,14 @@ function registerPlugin(name: string, plugin: any, options: any) {
   if (typeof plugin.onPostBuild === 'function') hooks.onPostBuild.push((ctx: any) => plugin.onPostBuild({ ...ctx, options }));
 
   if (typeof plugin.getAssets === 'function') hooks.assets.push(() => plugin.getAssets(options));
+
+  // Plugin actions (WebSocket RPC handlers)
+  if (plugin.actions && typeof plugin.actions === 'object') {
+    Object.assign(hooks.actions, plugin.actions);
+  }
+
+  // Plugin events (fire-and-forget handlers)
+  if (plugin.events && typeof plugin.events === 'object') {
+    Object.assign(hooks.events, plugin.events);
+  }
 }

--- a/packages/core/src/utils/source-tools.ts
+++ b/packages/core/src/utils/source-tools.ts
@@ -383,7 +383,7 @@ export function createSourceTools({ projectRoot }: { projectRoot: string }): Sou
       allLines.splice(absStart, absEnd - absStart);
 
       // Clean up consecutive blank lines around the removal point
-      let i = absStart;
+      const i = absStart;
       while (i < allLines.length - 1 && allLines[i].trim() === '' && allLines[i + 1].trim() === '') {
         allLines.splice(i, 1);
       }

--- a/packages/core/src/utils/source-tools.ts
+++ b/packages/core/src/utils/source-tools.ts
@@ -1,0 +1,397 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Source editing tools for live-edit plugins.
+ *
+ * Plugins interact with rendered output (block IDs, plain-text offsets)
+ * and these tools translate those references back to raw markdown source
+ * positions so edits can be applied safely.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createMarkdownProcessor } from '@docmd/parser';
+import type { BlockInfo, InlineSegment, SourceTools, TextLocation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve and validate a file path against the project root.
+ * Throws if the resolved path escapes the project root.
+ */
+function safePath(projectRoot: string, file: string): string {
+  const resolved = path.resolve(projectRoot, file);
+  if (!resolved.startsWith(projectRoot + path.sep) && resolved !== projectRoot) {
+    throw new Error(`Path "${file}" escapes the project root`);
+  }
+  return resolved;
+}
+
+/**
+ * Compute the number of lines occupied by YAML frontmatter (including the
+ * trailing blank line that gray-matter strips).  Mirrors the logic used in
+ * `processContent` from `@docmd/parser`.
+ */
+function computeFrontmatterOffset(raw: string): number {
+  if (!raw.startsWith('---')) return 0;
+  const closingIndex = raw.indexOf('---', 3);
+  if (closingIndex === -1) return 0;
+  let count = raw.substring(0, closingIndex + 3).split('\n').length;
+  if (raw[closingIndex + 3] === '\n') count++;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Inline segment builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Syntax marker lookup for open/close token pairs.
+ * Returns `[before, after]` strings that wrap the text content in raw markdown.
+ */
+function syntaxForToken(token: any): [string, string] | null {
+  switch (token.type) {
+    case 'strong_open':
+      return ['**', '**'];
+    case 'em_open':
+      return [token.markup || '*', token.markup || '*'];
+    case 's_open':
+      return ['~~', '~~'];
+    case 'link_open': {
+      const href = (token.attrs || []).find((a: string[]) => a[0] === 'href');
+      return ['[', `](${href ? href[1] : ''})`];
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build an array of inline segments from a raw markdown string.
+ *
+ * Each segment describes a contiguous run of text content and the surrounding
+ * syntax markers (if any).  `rawOffset` is the character index in `rawContent`
+ * where the segment's *text* starts (after the opening syntax marker).
+ */
+function buildSegments(rawContent: string, md: any): InlineSegment[] {
+  const tokens = md.parseInline(rawContent, {});
+  if (!tokens.length || !tokens[0].children) return [];
+
+  const children = tokens[0].children;
+  const segments: InlineSegment[] = [];
+  const syntaxStack: ([string, string] | null)[] = [];
+
+  // Walk the raw string in parallel with the token stream to compute
+  // rawOffset values.  `rawCursor` tracks our position in `rawContent`.
+  let rawCursor = 0;
+
+  for (const child of children) {
+    if (child.nesting === 1) {
+      // Opening tag — advance rawCursor past the opening marker
+      const syn = syntaxForToken(child);
+      if (syn) {
+        const markerPos = rawContent.indexOf(syn[0], rawCursor);
+        if (markerPos !== -1) {
+          rawCursor = markerPos + syn[0].length;
+        }
+      }
+      syntaxStack.push(syn);
+    } else if (child.nesting === -1) {
+      // Closing tag — advance rawCursor past the closing marker
+      const syn = syntaxStack.pop();
+      if (syn) {
+        const closeMarker = syn[1];
+        const markerPos = rawContent.indexOf(closeMarker, rawCursor);
+        if (markerPos !== -1) {
+          rawCursor = markerPos + closeMarker.length;
+        }
+      }
+    } else if (child.type === 'code_inline') {
+      // Self-contained segment with backtick syntax
+      const backtick = child.markup || '`';
+      const markerPos = rawContent.indexOf(backtick + child.content + backtick, rawCursor);
+      if (markerPos !== -1) {
+        segments.push({
+          text: child.content,
+          rawOffset: markerPos + backtick.length,
+          rawLength: child.content.length,
+          syntax: [backtick, backtick],
+        });
+        rawCursor = markerPos + backtick.length + child.content.length + backtick.length;
+      }
+    } else if (child.type === 'softbreak') {
+      // Treat as newline in text content — skip in raw
+      const nlPos = rawContent.indexOf('\n', rawCursor);
+      if (nlPos !== -1) rawCursor = nlPos + 1;
+    } else if (child.type === 'text') {
+      // Plain text or text inside a syntax wrapper
+      const textPos = rawContent.indexOf(child.content, rawCursor);
+      const currentSyntax = syntaxStack.length > 0 ? syntaxStack[syntaxStack.length - 1] : null;
+      if (textPos !== -1) {
+        segments.push({
+          text: child.content,
+          rawOffset: textPos,
+          rawLength: child.content.length,
+          syntax: currentSyntax,
+        });
+        rawCursor = textPos + child.content.length;
+      }
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Build plain text content from segments (concatenated segment texts).
+ */
+function plainTextFromSegments(segments: InlineSegment[]): string {
+  return segments.map((s) => s.text).join('');
+}
+
+/**
+ * Resolve a `textOffset` (character position in plain text) to the segment
+ * that contains it.
+ */
+function resolveCursor(
+  segments: InlineSegment[],
+  textOffset: number,
+): (InlineSegment & { segment: number }) | null {
+  let accumulated = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (accumulated + seg.text.length > textOffset) {
+      return { segment: i, ...seg };
+    }
+    accumulated += seg.text.length;
+  }
+  // If offset is exactly at the end, return the last segment
+  if (segments.length > 0) {
+    const last = segments[segments.length - 1];
+    return { segment: segments.length - 1, ...last };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a source-tools instance bound to the given project root.
+ *
+ * All file paths passed to the returned methods are resolved relative to
+ * `projectRoot` and validated against path traversal.
+ */
+export function createSourceTools({ projectRoot }: { projectRoot: string }): SourceTools & { _modified: boolean } {
+  // Normalise projectRoot to an absolute path without trailing separator
+  projectRoot = path.resolve(projectRoot);
+
+  // Create a markdown-it instance once (no dev features needed for parsing)
+  const md = createMarkdownProcessor({ isDev: false });
+
+  const tools: SourceTools & { _modified: boolean } = {
+    _modified: false,
+
+    // -------------------------------------------------------------------
+    // getBlockAt
+    // -------------------------------------------------------------------
+    async getBlockAt(
+      file: string,
+      blockRef: [number, number],
+      options?: { textOffset?: number },
+    ): Promise<BlockInfo> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const [startLine, endLine] = blockRef;
+      const absStart = fmOffset + startLine;
+      const absEnd = fmOffset + endLine;
+
+      const allLines = raw.split('\n');
+      const blockLines = allLines.slice(absStart, absEnd);
+      const rawBlock = blockLines.join('\n');
+
+      const segments = buildSegments(rawBlock, md);
+      const textContent = plainTextFromSegments(segments);
+
+      let cursor: (InlineSegment & { segment: number }) | null = null;
+      if (options && options.textOffset != null) {
+        cursor = resolveCursor(segments, options.textOffset);
+      }
+
+      return {
+        id: null,
+        line: { start: absStart, end: absEnd },
+        raw: rawBlock,
+        textContent,
+        segments,
+        cursor,
+        ancestors: [],
+      };
+    },
+
+    // -------------------------------------------------------------------
+    // findText
+    // -------------------------------------------------------------------
+    async findText(
+      file: string,
+      blockRef: [number, number],
+      text: string,
+      textOffset?: number,
+    ): Promise<TextLocation | null> {
+      const block = await tools.getBlockAt(file, blockRef, { textOffset });
+
+      // Find the segment containing the target text
+      let accumulated = 0;
+      for (const seg of block.segments) {
+        const idx = seg.text.indexOf(text);
+        if (idx !== -1 && accumulated + idx >= (textOffset != null ? textOffset : 0) - seg.text.length) {
+          const rawStartInBlock = seg.rawOffset + idx;
+          const rawEndInBlock = rawStartInBlock + text.length;
+
+          const filePath = safePath(projectRoot, file);
+          const raw = await fs.promises.readFile(filePath, 'utf8');
+          const fmOffset = computeFrontmatterOffset(raw);
+          const absLine = fmOffset + blockRef[0];
+
+          return {
+            line: absLine,
+            startCol: rawStartInBlock,
+            endCol: rawEndInBlock,
+            rawText: text,
+            wrappingSyntax: {
+              before: seg.syntax ? seg.syntax[0] : null,
+              after: seg.syntax ? seg.syntax[1] : null,
+            },
+          };
+        }
+        accumulated += seg.text.length;
+      }
+      return null;
+    },
+
+    // -------------------------------------------------------------------
+    // wrapText
+    // -------------------------------------------------------------------
+    async wrapText(
+      file: string,
+      blockRef: [number, number],
+      text: string,
+      textOffset: number,
+      before: string,
+      after: string,
+    ): Promise<void> {
+      const loc = await tools.findText(file, blockRef, text, textOffset);
+      if (!loc) throw new Error(`Text "${text}" not found in block`);
+
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const allLines = raw.split('\n');
+
+      const line = allLines[loc.line];
+      const newLine =
+        line.substring(0, loc.startCol) +
+        before +
+        line.substring(loc.startCol, loc.endCol) +
+        after +
+        line.substring(loc.endCol);
+
+      allLines[loc.line] = newLine;
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // insertAfter
+    // -------------------------------------------------------------------
+    async insertAfter(
+      file: string,
+      blockRef: [number, number],
+      content: string,
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+
+      // Insert content after the block with blank line padding
+      const insertLines = ['', ...content.split('\n')];
+      allLines.splice(absEnd, 0, ...insertLines);
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // replaceBlock
+    // -------------------------------------------------------------------
+    async replaceBlock(
+      file: string,
+      blockRef: [number, number],
+      content: string,
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const absStart = fmOffset + blockRef[0];
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+      const replacementLines = content.split('\n');
+      allLines.splice(absStart, absEnd - absStart, ...replacementLines);
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // removeBlock
+    // -------------------------------------------------------------------
+    async removeBlock(
+      file: string,
+      blockRef: [number, number],
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const absStart = fmOffset + blockRef[0];
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+
+      // Remove the block lines
+      allLines.splice(absStart, absEnd - absStart);
+
+      // Clean up consecutive blank lines around the removal point
+      let i = absStart;
+      while (i < allLines.length - 1 && allLines[i].trim() === '' && allLines[i + 1].trim() === '') {
+        allLines.splice(i, 1);
+      }
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+  };
+
+  return tools;
+}


### PR DESCRIPTION
## Summary

- Adds `action-dispatcher.ts` — routes WebSocket RPC calls to plugin action handlers with a sandboxed `ActionContext`
- Adds `source-tools.ts` — translates rendered-output references (block positions, text offsets) to raw markdown source positions for safe file editing
- All file I/O is async (`fs.promises`) and path-sandboxed (`safePath` rejects traversal)

## Context

Part of the plugin API infrastructure discussed in #73. Depends on #95 (plugin actions/events hooks).

The action dispatcher creates a fresh `ActionContext` per call with:
- `readFile`, `writeFile`, `readFileLines` — sandboxed to project root
- `source` — block-level editing tools (getBlockAt, findText, wrapText, insertAfter, replaceBlock, removeBlock)
- `broadcast` — push events to connected browser clients
- Modification tracking for automatic reload signaling

## Changes

| File | Change |
|------|--------|
| `packages/core/src/utils/action-dispatcher.ts` | New: action routing + sandboxed context |
| `packages/core/src/utils/source-tools.ts` | New: markdown source editing tools |
| `packages/core/src/index.ts` | Export new modules |

## Test plan

- [ ] Unit test `safePath`: rejects `../../../etc/passwd`, accepts `docs/index.md`
- [ ] Unit test dispatcher: mock handler returns result, verify `{ result, reload }` 
- [ ] Unit test source-tools with fixture markdown: `getBlockAt`, `findText`, `wrapText`
- [ ] Run `pnpm test`