### PR TITLE
feat(core): add WebSocket RPC protocol and browser API client

### DIFF
--- a/packages/core/src/commands/dev.ts
+++ b/packages/core/src/commands/dev.ts
@@ -80,8 +80,8 @@ function getNetworkIp() {
 function getGitDevInfo() {
   let name = '';
   let email = '';
-  try { name = execSync('git config user.name', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch {}
-  try { email = execSync('git config user.email', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch {}
+  try { name = execSync('git config user.name', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch { /* git not configured */ }
+  try { email = execSync('git config user.email', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch { /* git not configured */ }
   const gravatarUrl = email
     ? `https://gravatar.com/avatar/${crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex')}?s=80&d=mp`
     : '';

--- a/packages/core/src/commands/dev.ts
+++ b/packages/core/src/commands/dev.ts
@@ -24,6 +24,10 @@ import { buildSite } from './build.js';
 import { loadConfig } from '../utils/config-loader.js';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import crypto from 'crypto';
+import { execSync } from 'child_process';
+import { createActionDispatcher } from '../utils/action-dispatcher.js';
+import { loadPlugins, hooks } from '../utils/plugin-loader.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -69,9 +73,44 @@ function getNetworkIp() {
   return null;
 }
 
+/**
+ * Read git user.name and user.email, compute Gravatar URL.
+ * Returns a JSON-safe object for injection into the client.
+ */
+function getGitDevInfo() {
+  let name = '';
+  let email = '';
+  try { name = execSync('git config user.name', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch {}
+  try { email = execSync('git config user.email', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim(); } catch {}
+  const gravatarUrl = email
+    ? `https://gravatar.com/avatar/${crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex')}?s=80&d=mp`
+    : '';
+  return { name, email, gravatarUrl };
+}
+
+const _gitDevInfo = getGitDevInfo();
+const _devInfoScript = `<script>window.__docmd_dev=${JSON.stringify(_gitDevInfo)}</script>`;
+
 // Static Server Logic
 
 async function serveStatic(req, res, rootDir) {
+  // Serve dev-only API script
+  if (req.url === '/__dev/docmd-api.js') {
+    try {
+      const apiScriptPath = path.resolve(
+        fileURLToPath(import.meta.url),
+        '../../../../ui/assets/js/docmd-api.js'
+      );
+      const apiScript = await fs.readFile(apiScriptPath, 'utf-8');
+      res.writeHead(200, { 'Content-Type': 'text/javascript' });
+      res.end(apiScript);
+    } catch (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+    return;
+  }
+
   let safePath = path.normalize(req.url).replace(/^(\.\.[\/\\])+/, '').split('?')[0].split('#')[0];
   if (safePath === '/' || safePath === '\\') safePath = 'index.html';
 
@@ -109,27 +148,7 @@ async function serveStatic(req, res, rootDir) {
 
     if (contentType === 'text/html') {
       const htmlStr = content.toString('utf-8');
-      const liveReloadScript = `
-        <script>
-          (function() {
-            let socket;
-            let retryCount = 0;
-            const maxRetries = 50;
-            function connect() {
-              if (socket && (socket.readyState === 0 || socket.readyState === 1)) return;
-              socket = new WebSocket('ws://' + window.location.host);
-              socket.onopen = () => { console.log('⚡ docmd connected'); retryCount = 0; };
-              socket.onmessage = (e) => { if(e.data === 'reload') window.location.reload(); };
-              socket.onclose = () => {
-                if (retryCount < maxRetries) {
-                    retryCount++;
-                    setTimeout(connect, Math.min(1000 * (1.5 ** retryCount), 5000));
-                }
-              };
-            }
-            setTimeout(connect, 500);
-          })();
-        </script></body>`;
+      const liveReloadScript = `${_devInfoScript}<script src="/__dev/docmd-api.js"></script></body>`;
       res.end(htmlStr.replace('</body>', liveReloadScript));
     } else {
       res.end(content);
@@ -146,18 +165,7 @@ async function serveStatic(req, res, rootDir) {
 
         // Inject Live Reload into 404 page too so development continues smoothly
         const htmlStr = content.toString('utf-8');
-        const liveReloadScript = `
-        <script>
-          (function() {
-            let socket;
-            function connect() {
-              socket = new WebSocket('ws://' + window.location.host);
-              socket.onmessage = (e) => { if(e.data === 'reload') window.location.reload(); };
-              socket.onclose = () => setTimeout(connect, 1000);
-            }
-            setTimeout(connect, 500);
-          })();
-        </script></body>`;
+        const liveReloadScript = `${_devInfoScript}<script src="/__dev/docmd-api.js"></script></body>`;
         res.end(htmlStr.replace('</body>', liveReloadScript));
       } catch (e2) {
         // 2. Fallback if 404.html doesn't exist (e.g. build failed)
@@ -344,6 +352,40 @@ export async function startDevServer(configPathOption: string, opts: any = {}) {
       .once('listening', async () => {
         wss = new WebSocketServer({ server });
         wss.on('error', (e: any) => console.error('WebSocket Error:', e.message));
+
+        // Action dispatcher for plugin actions/events
+        await loadPlugins(config);
+        const dispatcher = createActionDispatcher(hooks, {
+          projectRoot: CWD,
+          config,
+          broadcast: (event: string, data: any) => {
+            wss.clients.forEach((client: any) => {
+              if (client.readyState === WebSocket.OPEN) {
+                client.send(JSON.stringify({ type: 'event', name: event, data }));
+              }
+            });
+          }
+        });
+
+        wss.on('connection', (ws: any) => {
+          ws.on('message', async (raw: any) => {
+            let msg: any;
+            try { msg = JSON.parse(raw.toString()); } catch { return; }
+
+            if (msg.type === 'call') {
+              try {
+                const { result, reload } = await dispatcher.handleCall(msg.action, msg.payload);
+                // Don't send reload flag to client — let the file watcher detect
+                // the change, rebuild, and send the reload via broadcastReload()
+                ws.send(JSON.stringify({ id: msg.id, type: 'response', result, reload: false }));
+              } catch (e: any) {
+                ws.send(JSON.stringify({ id: msg.id, type: 'response', error: e.message }));
+              }
+            } else if (msg.type === 'event') {
+              dispatcher.handleEvent(msg.name, msg.data);
+            }
+          });
+        });
 
         const indexHtmlPath = path.join(paths.outputDir, 'index.html');
         const networkIp = getNetworkIp();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,10 @@ export { buildSite as build } from './commands/build.js';
 export { startDevServer as dev } from './commands/dev.js';
 export { buildLive } from './commands/live.js';
 
+// Action dispatcher and source editing tools
+export { createActionDispatcher, safePath } from './utils/action-dispatcher.js';
+export { createSourceTools } from './utils/source-tools.js';
+
 // Plugin API types
 export type {
   ActionContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,3 +19,16 @@ export function defineConfig(config: any): any {
 export { buildSite as build } from './commands/build.js';
 export { startDevServer as dev } from './commands/dev.js';
 export { buildLive } from './commands/live.js';
+
+// Plugin API types
+export type {
+  ActionContext,
+  ActionHandler,
+  EventHandler,
+  DispatchResult,
+  PluginModule,
+  SourceTools,
+  BlockInfo,
+  InlineSegment,
+  TextLocation,
+} from './types.js';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Context provided to plugin action and event handlers.
+ *
+ * Contains file I/O helpers, source editing tools, and project metadata.
+ * All file operations are sandboxed to the project root directory.
+ */
+export interface ActionContext {
+  /** Absolute path to the project root directory. */
+  projectRoot: string;
+  /** Current docmd site configuration. */
+  config: any;
+  /** Read a file relative to the project root. */
+  readFile(relativePath: string): Promise<string>;
+  /** Write a file relative to the project root. Sets the modification flag. */
+  writeFile(relativePath: string, content: string): Promise<void>;
+  /** Read a file as an array of lines. */
+  readFileLines(relativePath: string): Promise<string[]>;
+  /** Broadcast an event to all connected browser clients. */
+  broadcast(event: string, data: any): void;
+  /** Source editing tools for block-level markdown manipulation. */
+  source: SourceTools;
+}
+
+/**
+ * Source editing tools that translate rendered-output references
+ * (block IDs, text offsets) back to raw markdown source positions.
+ */
+export interface SourceTools {
+  /** Get block content and inline segments at a given source map reference. */
+  getBlockAt(file: string, blockRef: [number, number], options?: { textOffset?: number }): Promise<BlockInfo>;
+  /** Locate text within a block and return its source position. */
+  findText(file: string, blockRef: [number, number], text: string, textOffset?: number): Promise<TextLocation | null>;
+  /** Wrap text within a block with syntax markers (e.g., `==`, `**`). */
+  wrapText(file: string, blockRef: [number, number], text: string, textOffset: number, before: string, after: string): Promise<void>;
+  /** Insert markdown content after a block. */
+  insertAfter(file: string, blockRef: [number, number], content: string): Promise<void>;
+  /** Replace an entire block's source lines. */
+  replaceBlock(file: string, blockRef: [number, number], content: string): Promise<void>;
+  /** Remove a block's source lines. */
+  removeBlock(file: string, blockRef: [number, number]): Promise<void>;
+}
+
+/** Information about a block in the markdown source. */
+export interface BlockInfo {
+  id: string | null;
+  line: { start: number; end: number };
+  raw: string;
+  textContent: string;
+  segments: InlineSegment[];
+  cursor: InlineSegment | null;
+  ancestors: any[];
+}
+
+/** A contiguous run of text content with optional surrounding syntax. */
+export interface InlineSegment {
+  text: string;
+  rawOffset: number;
+  rawLength: number;
+  syntax: [string, string] | null;
+}
+
+/** Source position of located text within a block. */
+export interface TextLocation {
+  line: number;
+  startCol: number;
+  endCol: number;
+  rawText: string;
+  wrappingSyntax: { before: string | null; after: string | null };
+}
+
+/**
+ * Handler for a named plugin action (WebSocket RPC).
+ * Returns a result that is sent back to the browser client.
+ */
+export type ActionHandler = (payload: any, ctx: ActionContext) => Promise<any>;
+
+/** Handler for a fire-and-forget plugin event. */
+export type EventHandler = (data: any, ctx: ActionContext) => void;
+
+/** Result of dispatching an action call. */
+export interface DispatchResult {
+  result: any;
+  reload: boolean;
+}
+
+/**
+ * Interface for a docmd plugin module.
+ *
+ * Plugins can export any combination of build-time hooks and runtime
+ * action/event handlers.
+ */
+export interface PluginModule {
+  /** Extend the markdown-it parser instance. */
+  markdownSetup?(md: any, options?: any): void;
+  /** Inject meta/link tags into the HTML head. */
+  generateMetaTags?(config: any, page: any, relativePathToRoot: string): string | Promise<string>;
+  /** Inject scripts into head and/or body. */
+  generateScripts?(config: any, options?: any): { headScriptsHtml?: string; bodyScriptsHtml?: string };
+  /** Define external assets (JS/CSS) to inject. */
+  getAssets?(options?: any): any[];
+  /** Run logic after all HTML files are generated. */
+  onPostBuild?(ctx: any): Promise<void>;
+  /** Named action handlers for WebSocket RPC calls from the browser. */
+  actions?: Record<string, ActionHandler>;
+  /** Named event handlers for fire-and-forget messages from the browser. */
+  events?: Record<string, EventHandler>;
+}

--- a/packages/core/src/utils/action-dispatcher.ts
+++ b/packages/core/src/utils/action-dispatcher.ts
@@ -1,0 +1,116 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Action dispatcher for live-edit WebSocket message handling.
+ *
+ * Routes incoming `call` messages to plugin action handlers and `event`
+ * messages to plugin event handlers.  Each call gets a fresh context with
+ * file I/O helpers and source editing tools.  Tracks modifications so the
+ * caller knows whether a browser reload is needed.
+ */
+
+import path from 'path';
+import fs from 'fs';
+import { createSourceTools } from './source-tools.js';
+import type {
+  ActionContext,
+  ActionHandler,
+  EventHandler,
+  DispatchResult,
+} from '../types.js';
+
+/**
+ * Resolve a relative path against the project root, rejecting any path
+ * that would escape the root directory.
+ */
+export function safePath(root: string, relativePath: string): string {
+  const resolved = path.resolve(root, relativePath);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw new Error(`Path escapes project root: ${relativePath}`);
+  }
+  return resolved;
+}
+
+interface DispatcherHooks {
+  actions: Record<string, ActionHandler>;
+  events: Record<string, EventHandler>;
+}
+
+interface DispatcherOptions {
+  projectRoot: string;
+  config: any;
+  broadcast: (event: string, data: any) => void;
+}
+
+/**
+ * Create an action dispatcher bound to the given hooks and project context.
+ *
+ * @param hooks     - `{ actions: {name: handler}, events: {name: handler} }`
+ * @param options   - Project root, config, and broadcast function
+ * @returns `{ handleCall, handleEvent }`
+ */
+export function createActionDispatcher(hooks: DispatcherHooks, options: DispatcherOptions) {
+  const { projectRoot, config, broadcast } = options;
+
+  return {
+    /**
+     * Dispatch a call-style action.  Returns `{ result, reload }`.
+     */
+    async handleCall(action: string, payload: any): Promise<DispatchResult> {
+      const handler = hooks.actions[action];
+      if (!handler) throw new Error(`Unknown action: ${action}`);
+
+      const sourceTools = createSourceTools({ projectRoot });
+      let modified = false;
+
+      const ctx: ActionContext = {
+        projectRoot,
+        config,
+        broadcast,
+        source: sourceTools,
+        async readFile(relativePath: string): Promise<string> {
+          const resolved = safePath(projectRoot, relativePath);
+          return fs.promises.readFile(resolved, 'utf8');
+        },
+        async writeFile(relativePath: string, content: string): Promise<void> {
+          const resolved = safePath(projectRoot, relativePath);
+          await fs.promises.writeFile(resolved, content);
+          modified = true;
+        },
+        async readFileLines(relativePath: string): Promise<string[]> {
+          const content = await ctx.readFile(relativePath);
+          return content.split('\n');
+        },
+      };
+
+      const result = await handler(payload, ctx);
+      return { result, reload: modified || sourceTools._modified };
+    },
+
+    /**
+     * Dispatch a fire-and-forget event.  Unknown events are silently ignored.
+     */
+    handleEvent(name: string, data: any): void {
+      const handler = hooks.events[name];
+      if (!handler) return;
+      const ctx = { projectRoot, config, broadcast } as ActionContext;
+      try {
+        handler(data, ctx);
+      } catch (e: any) {
+        console.error(`Event handler error [${name}]:`, e.message);
+      }
+    },
+  };
+}

--- a/packages/core/src/utils/plugin-loader.ts
+++ b/packages/core/src/utils/plugin-loader.ts
@@ -24,7 +24,9 @@ export const hooks: any = {
   injectBody: [],
   onPostBuild: [],
   assets: [],
-  getClientAssets: [] // Legacy support
+  getClientAssets: [], // Legacy support
+  actions: {},         // action name → handler function (for WebSocket RPC)
+  events: {}           // event name → handler function (fire-and-forget)
 };
 
 // Map short names to package names
@@ -40,7 +42,9 @@ const ALIASES: Record<string, string> = {
 
 export async function loadPlugins(config: any) {
   // 1. Reset hooks
-  Object.keys(hooks).forEach(key => hooks[key] = []);
+  Object.keys(hooks).forEach(key => {
+    hooks[key] = Array.isArray(hooks[key]) ? [] : {};
+  });
 
   // 2. Initialize Plugin Map (Name -> Options)
   // This ensures unique plugins (last write wins)
@@ -111,4 +115,14 @@ function registerPlugin(name: string, plugin: any, options: any) {
   if (typeof plugin.onPostBuild === 'function') hooks.onPostBuild.push((ctx: any) => plugin.onPostBuild({ ...ctx, options }));
 
   if (typeof plugin.getAssets === 'function') hooks.assets.push(() => plugin.getAssets(options));
+
+  // Plugin actions (WebSocket RPC handlers)
+  if (plugin.actions && typeof plugin.actions === 'object') {
+    Object.assign(hooks.actions, plugin.actions);
+  }
+
+  // Plugin events (fire-and-forget handlers)
+  if (plugin.events && typeof plugin.events === 'object') {
+    Object.assign(hooks.events, plugin.events);
+  }
 }

--- a/packages/core/src/utils/source-tools.ts
+++ b/packages/core/src/utils/source-tools.ts
@@ -383,7 +383,7 @@ export function createSourceTools({ projectRoot }: { projectRoot: string }): Sou
       allLines.splice(absStart, absEnd - absStart);
 
       // Clean up consecutive blank lines around the removal point
-      let i = absStart;
+      const i = absStart;
       while (i < allLines.length - 1 && allLines[i].trim() === '' && allLines[i + 1].trim() === '') {
         allLines.splice(i, 1);
       }

--- a/packages/core/src/utils/source-tools.ts
+++ b/packages/core/src/utils/source-tools.ts
@@ -1,0 +1,397 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025-present docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Source editing tools for live-edit plugins.
+ *
+ * Plugins interact with rendered output (block IDs, plain-text offsets)
+ * and these tools translate those references back to raw markdown source
+ * positions so edits can be applied safely.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { createMarkdownProcessor } from '@docmd/parser';
+import type { BlockInfo, InlineSegment, SourceTools, TextLocation } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve and validate a file path against the project root.
+ * Throws if the resolved path escapes the project root.
+ */
+function safePath(projectRoot: string, file: string): string {
+  const resolved = path.resolve(projectRoot, file);
+  if (!resolved.startsWith(projectRoot + path.sep) && resolved !== projectRoot) {
+    throw new Error(`Path "${file}" escapes the project root`);
+  }
+  return resolved;
+}
+
+/**
+ * Compute the number of lines occupied by YAML frontmatter (including the
+ * trailing blank line that gray-matter strips).  Mirrors the logic used in
+ * `processContent` from `@docmd/parser`.
+ */
+function computeFrontmatterOffset(raw: string): number {
+  if (!raw.startsWith('---')) return 0;
+  const closingIndex = raw.indexOf('---', 3);
+  if (closingIndex === -1) return 0;
+  let count = raw.substring(0, closingIndex + 3).split('\n').length;
+  if (raw[closingIndex + 3] === '\n') count++;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Inline segment builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Syntax marker lookup for open/close token pairs.
+ * Returns `[before, after]` strings that wrap the text content in raw markdown.
+ */
+function syntaxForToken(token: any): [string, string] | null {
+  switch (token.type) {
+    case 'strong_open':
+      return ['**', '**'];
+    case 'em_open':
+      return [token.markup || '*', token.markup || '*'];
+    case 's_open':
+      return ['~~', '~~'];
+    case 'link_open': {
+      const href = (token.attrs || []).find((a: string[]) => a[0] === 'href');
+      return ['[', `](${href ? href[1] : ''})`];
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build an array of inline segments from a raw markdown string.
+ *
+ * Each segment describes a contiguous run of text content and the surrounding
+ * syntax markers (if any).  `rawOffset` is the character index in `rawContent`
+ * where the segment's *text* starts (after the opening syntax marker).
+ */
+function buildSegments(rawContent: string, md: any): InlineSegment[] {
+  const tokens = md.parseInline(rawContent, {});
+  if (!tokens.length || !tokens[0].children) return [];
+
+  const children = tokens[0].children;
+  const segments: InlineSegment[] = [];
+  const syntaxStack: ([string, string] | null)[] = [];
+
+  // Walk the raw string in parallel with the token stream to compute
+  // rawOffset values.  `rawCursor` tracks our position in `rawContent`.
+  let rawCursor = 0;
+
+  for (const child of children) {
+    if (child.nesting === 1) {
+      // Opening tag — advance rawCursor past the opening marker
+      const syn = syntaxForToken(child);
+      if (syn) {
+        const markerPos = rawContent.indexOf(syn[0], rawCursor);
+        if (markerPos !== -1) {
+          rawCursor = markerPos + syn[0].length;
+        }
+      }
+      syntaxStack.push(syn);
+    } else if (child.nesting === -1) {
+      // Closing tag — advance rawCursor past the closing marker
+      const syn = syntaxStack.pop();
+      if (syn) {
+        const closeMarker = syn[1];
+        const markerPos = rawContent.indexOf(closeMarker, rawCursor);
+        if (markerPos !== -1) {
+          rawCursor = markerPos + closeMarker.length;
+        }
+      }
+    } else if (child.type === 'code_inline') {
+      // Self-contained segment with backtick syntax
+      const backtick = child.markup || '`';
+      const markerPos = rawContent.indexOf(backtick + child.content + backtick, rawCursor);
+      if (markerPos !== -1) {
+        segments.push({
+          text: child.content,
+          rawOffset: markerPos + backtick.length,
+          rawLength: child.content.length,
+          syntax: [backtick, backtick],
+        });
+        rawCursor = markerPos + backtick.length + child.content.length + backtick.length;
+      }
+    } else if (child.type === 'softbreak') {
+      // Treat as newline in text content — skip in raw
+      const nlPos = rawContent.indexOf('\n', rawCursor);
+      if (nlPos !== -1) rawCursor = nlPos + 1;
+    } else if (child.type === 'text') {
+      // Plain text or text inside a syntax wrapper
+      const textPos = rawContent.indexOf(child.content, rawCursor);
+      const currentSyntax = syntaxStack.length > 0 ? syntaxStack[syntaxStack.length - 1] : null;
+      if (textPos !== -1) {
+        segments.push({
+          text: child.content,
+          rawOffset: textPos,
+          rawLength: child.content.length,
+          syntax: currentSyntax,
+        });
+        rawCursor = textPos + child.content.length;
+      }
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Build plain text content from segments (concatenated segment texts).
+ */
+function plainTextFromSegments(segments: InlineSegment[]): string {
+  return segments.map((s) => s.text).join('');
+}
+
+/**
+ * Resolve a `textOffset` (character position in plain text) to the segment
+ * that contains it.
+ */
+function resolveCursor(
+  segments: InlineSegment[],
+  textOffset: number,
+): (InlineSegment & { segment: number }) | null {
+  let accumulated = 0;
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    if (accumulated + seg.text.length > textOffset) {
+      return { segment: i, ...seg };
+    }
+    accumulated += seg.text.length;
+  }
+  // If offset is exactly at the end, return the last segment
+  if (segments.length > 0) {
+    const last = segments[segments.length - 1];
+    return { segment: segments.length - 1, ...last };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a source-tools instance bound to the given project root.
+ *
+ * All file paths passed to the returned methods are resolved relative to
+ * `projectRoot` and validated against path traversal.
+ */
+export function createSourceTools({ projectRoot }: { projectRoot: string }): SourceTools & { _modified: boolean } {
+  // Normalise projectRoot to an absolute path without trailing separator
+  projectRoot = path.resolve(projectRoot);
+
+  // Create a markdown-it instance once (no dev features needed for parsing)
+  const md = createMarkdownProcessor({ isDev: false });
+
+  const tools: SourceTools & { _modified: boolean } = {
+    _modified: false,
+
+    // -------------------------------------------------------------------
+    // getBlockAt
+    // -------------------------------------------------------------------
+    async getBlockAt(
+      file: string,
+      blockRef: [number, number],
+      options?: { textOffset?: number },
+    ): Promise<BlockInfo> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const [startLine, endLine] = blockRef;
+      const absStart = fmOffset + startLine;
+      const absEnd = fmOffset + endLine;
+
+      const allLines = raw.split('\n');
+      const blockLines = allLines.slice(absStart, absEnd);
+      const rawBlock = blockLines.join('\n');
+
+      const segments = buildSegments(rawBlock, md);
+      const textContent = plainTextFromSegments(segments);
+
+      let cursor: (InlineSegment & { segment: number }) | null = null;
+      if (options && options.textOffset != null) {
+        cursor = resolveCursor(segments, options.textOffset);
+      }
+
+      return {
+        id: null,
+        line: { start: absStart, end: absEnd },
+        raw: rawBlock,
+        textContent,
+        segments,
+        cursor,
+        ancestors: [],
+      };
+    },
+
+    // -------------------------------------------------------------------
+    // findText
+    // -------------------------------------------------------------------
+    async findText(
+      file: string,
+      blockRef: [number, number],
+      text: string,
+      textOffset?: number,
+    ): Promise<TextLocation | null> {
+      const block = await tools.getBlockAt(file, blockRef, { textOffset });
+
+      // Find the segment containing the target text
+      let accumulated = 0;
+      for (const seg of block.segments) {
+        const idx = seg.text.indexOf(text);
+        if (idx !== -1 && accumulated + idx >= (textOffset != null ? textOffset : 0) - seg.text.length) {
+          const rawStartInBlock = seg.rawOffset + idx;
+          const rawEndInBlock = rawStartInBlock + text.length;
+
+          const filePath = safePath(projectRoot, file);
+          const raw = await fs.promises.readFile(filePath, 'utf8');
+          const fmOffset = computeFrontmatterOffset(raw);
+          const absLine = fmOffset + blockRef[0];
+
+          return {
+            line: absLine,
+            startCol: rawStartInBlock,
+            endCol: rawEndInBlock,
+            rawText: text,
+            wrappingSyntax: {
+              before: seg.syntax ? seg.syntax[0] : null,
+              after: seg.syntax ? seg.syntax[1] : null,
+            },
+          };
+        }
+        accumulated += seg.text.length;
+      }
+      return null;
+    },
+
+    // -------------------------------------------------------------------
+    // wrapText
+    // -------------------------------------------------------------------
+    async wrapText(
+      file: string,
+      blockRef: [number, number],
+      text: string,
+      textOffset: number,
+      before: string,
+      after: string,
+    ): Promise<void> {
+      const loc = await tools.findText(file, blockRef, text, textOffset);
+      if (!loc) throw new Error(`Text "${text}" not found in block`);
+
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const allLines = raw.split('\n');
+
+      const line = allLines[loc.line];
+      const newLine =
+        line.substring(0, loc.startCol) +
+        before +
+        line.substring(loc.startCol, loc.endCol) +
+        after +
+        line.substring(loc.endCol);
+
+      allLines[loc.line] = newLine;
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // insertAfter
+    // -------------------------------------------------------------------
+    async insertAfter(
+      file: string,
+      blockRef: [number, number],
+      content: string,
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+
+      // Insert content after the block with blank line padding
+      const insertLines = ['', ...content.split('\n')];
+      allLines.splice(absEnd, 0, ...insertLines);
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // replaceBlock
+    // -------------------------------------------------------------------
+    async replaceBlock(
+      file: string,
+      blockRef: [number, number],
+      content: string,
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const absStart = fmOffset + blockRef[0];
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+      const replacementLines = content.split('\n');
+      allLines.splice(absStart, absEnd - absStart, ...replacementLines);
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+
+    // -------------------------------------------------------------------
+    // removeBlock
+    // -------------------------------------------------------------------
+    async removeBlock(
+      file: string,
+      blockRef: [number, number],
+    ): Promise<void> {
+      const filePath = safePath(projectRoot, file);
+      const raw = await fs.promises.readFile(filePath, 'utf8');
+      const fmOffset = computeFrontmatterOffset(raw);
+
+      const absStart = fmOffset + blockRef[0];
+      const absEnd = fmOffset + blockRef[1];
+
+      const allLines = raw.split('\n');
+
+      // Remove the block lines
+      allLines.splice(absStart, absEnd - absStart);
+
+      // Clean up consecutive blank lines around the removal point
+      let i = absStart;
+      while (i < allLines.length - 1 && allLines[i].trim() === '' && allLines[i + 1].trim() === '') {
+        allLines.splice(i, 1);
+      }
+
+      await fs.promises.writeFile(filePath, allLines.join('\n'));
+      tools._modified = true;
+    },
+  };
+
+  return tools;
+}

--- a/packages/ui/assets/js/docmd-api.js
+++ b/packages/ui/assets/js/docmd-api.js
@@ -1,3 +1,4 @@
+/* global WebSocket, sessionStorage, queueMicrotask */
 /**
  * --------------------------------------------------------------------
  * docmd : the minimalist, zero-config documentation generator.

--- a/packages/ui/assets/js/docmd-api.js
+++ b/packages/ui/assets/js/docmd-api.js
@@ -1,0 +1,164 @@
+/**
+ * --------------------------------------------------------------------
+ * docmd : the minimalist, zero-config documentation generator.
+ *
+ * @package     @docmd/core (and ecosystem)
+ * @website     https://docmd.io
+ * @repository  https://github.com/docmd-io/docmd
+ * @license     MIT
+ * @copyright   Copyright (c) 2025 docmd.io
+ *
+ * [docmd-source] - Please do not remove this header.
+ * --------------------------------------------------------------------
+ */
+
+/**
+ * Browser API for docmd plugin communication.
+ *
+ * Provides docmd.call(), docmd.send(), docmd.on(), docmd.afterReload(),
+ * and docmd.scheduleReload() over a WebSocket connection.
+ * Injected automatically by the dev server.
+ */
+(function() {
+  if (typeof window === 'undefined') return;
+  if (window.docmd && window.docmd.call) return; // already initialized
+
+  const docmd = window.docmd || {};
+  window.docmd = docmd;
+
+  let socket = null;
+  let messageId = 0;
+  const pendingCalls = new Map(); // id → { resolve, reject }
+  const eventListeners = new Map(); // name → Set<callback>
+
+  function connect() {
+    if (socket && (socket.readyState === 0 || socket.readyState === 1)) return;
+    socket = new WebSocket('ws://' + window.location.host);
+    let retryCount = 0;
+    const maxRetries = 50;
+
+    socket.onopen = () => {
+      console.log('⚡ docmd connected');
+      retryCount = 0;
+    };
+
+    socket.onmessage = (e) => {
+      if (e.data === 'reload') {
+        window.location.reload();
+        return;
+      }
+      let msg;
+      try { msg = JSON.parse(e.data); } catch { return; }
+
+      if (msg.type === 'response' && msg.id) {
+        const pending = pendingCalls.get(msg.id);
+        if (pending) {
+          pendingCalls.delete(msg.id);
+          if (msg.error) {
+            pending.reject(new Error(msg.error));
+          } else {
+            pending.resolve({ result: msg.result, reload: msg.reload });
+          }
+        }
+      } else if (msg.type === 'event' && msg.name) {
+        const listeners = eventListeners.get(msg.name);
+        if (listeners) {
+          listeners.forEach(cb => { try { cb(msg.data); } catch (e) { console.error(e); } });
+        }
+      }
+    };
+
+    socket.onclose = () => {
+      if (retryCount < maxRetries) {
+        retryCount++;
+        setTimeout(connect, Math.min(1000 * (1.5 ** retryCount), 5000));
+      }
+    };
+  }
+
+  function waitForConnection() {
+    if (socket && socket.readyState === 1) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('docmd: WebSocket connection timeout')), 5000);
+      function check() {
+        if (socket && socket.readyState === 1) {
+          clearTimeout(timeout);
+          resolve();
+        } else {
+          setTimeout(check, 50);
+        }
+      }
+      check();
+    });
+  }
+
+  /**
+   * Call a server-side action and return the result.
+   * If the action modifies files, the page reloads automatically after
+   * the promise resolves and the current microtask completes.
+   */
+  docmd.call = async function(action, payload) {
+    await waitForConnection();
+    return new Promise((resolve, reject) => {
+      const id = String(++messageId);
+      pendingCalls.set(id, {
+        resolve: ({ result, reload }) => {
+          resolve(result);
+          if (reload) {
+            queueMicrotask(() => window.location.reload());
+          }
+        },
+        reject
+      });
+      socket.send(JSON.stringify({ id, type: 'call', action, payload }));
+    });
+  };
+
+  /**
+   * Send a fire-and-forget event to the server.
+   */
+  docmd.send = async function(name, data) {
+    await waitForConnection();
+    socket.send(JSON.stringify({ type: 'event', name, data }));
+  };
+
+  /**
+   * Subscribe to server-pushed events. Returns an unsubscribe function.
+   */
+  docmd.on = function(name, callback) {
+    if (!eventListeners.has(name)) eventListeners.set(name, new Set());
+    eventListeners.get(name).add(callback);
+    return () => eventListeners.get(name).delete(callback);
+  };
+
+  /**
+   * Declare a named reload handler. Runs on every page load.
+   * If sessionStorage has stashed context for this name, calls the
+   * callback immediately with that context and clears the stash.
+   */
+  docmd.afterReload = function(name, callback) {
+    const key = 'docmd:reload:' + name;
+    const raw = sessionStorage.getItem(key);
+    if (raw) {
+      sessionStorage.removeItem(key);
+      try {
+        const context = JSON.parse(raw);
+        callback(context);
+      } catch (e) {
+        console.error('docmd.afterReload[' + name + '] error:', e);
+      }
+    }
+  };
+
+  /**
+   * Stash context for a named reload handler. The matching afterReload
+   * handler will fire with this context after the next page reload.
+   */
+  docmd.scheduleReload = function(name, context) {
+    const key = 'docmd:reload:' + name;
+    sessionStorage.setItem(key, JSON.stringify(context || {}));
+  };
+
+  // Connect
+  setTimeout(connect, 100);
+})();


### PR DESCRIPTION
## Summary

- Upgrades the dev server WebSocket to handle JSON-based RPC alongside the existing `'reload'` string protocol
- Adds `docmd-api.js` browser client with `docmd.call()`, `docmd.send()`, `docmd.on()`, `docmd.afterReload()`, `docmd.scheduleReload()`
- Injects git user identity (`window.__docmd_dev`) for plugin auth features
- Backwards compatible — the browser API still handles plain `'reload'` messages

## Context

Part of the plugin API infrastructure discussed in #73. Depends on #95 and #96.

This is the final piece that wires the action dispatcher into the dev server. The browser API replaces the inline live-reload script with a served file at `/__dev/docmd-api.js` that handles both live-reload and plugin RPC.

### Wire protocol
```json
// call (client → server)
{"id": "a1b2", "type": "call", "action": "threads:add-thread", "payload": {...}}
// response (server → client)  
{"id": "a1b2", "type": "response", "result": {...}, "reload": false}
// event (either direction)
{"type": "event", "name": "threads:comment-added", "data": {...}}
```

Note: `reload: false` in responses — file changes are detected by chokidar which triggers rebuild + broadcastReload, preventing double-reload.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/commands/dev.ts` | WebSocket message handling, action dispatch, `/__dev/` route, git identity injection |
| `packages/ui/assets/js/docmd-api.js` | New: browser-side RPC client (IIFE) |

## Test plan

- [ ] Start dev server, connect WebSocket, send `call` message, verify `response`
- [ ] Verify `'reload'` string messages still trigger page reload (backwards compat)
- [ ] Verify `/__dev/docmd-api.js` is served with correct Content-Type
- [ ] Run `pnpm test`